### PR TITLE
Added ServiceCNAME for Text to speech configuration.

### DIFF
--- a/Samples/Csharp/RealtimeMedia/TextToSpeech/ServiceConfiguration.Cloud.cscfg
+++ b/Samples/Csharp/RealtimeMedia/TextToSpeech/ServiceConfiguration.Cloud.cscfg
@@ -5,7 +5,8 @@
     <ConfigurationSettings>
       <!-- Replace $ConnectionString$ with the Connection String found on the ‘Access Keys’ of your Storage Account. -->
       <Setting name="Microsoft.WindowsAzure.Plugins.Diagnostics.ConnectionString" value="$ConnectionString$" />
-      <Setting name="ServiceDnsName" value="$ServiceDnsName$" />  <!-- xyz.cloudapp.net--> 
+      <Setting name="ServiceDnsName" value="$ServiceDnsName$" /><!-- xyz.cloudapp.net-->
+      <Setting name="ServiceCNAME" value="$ServiceCNAME$" /><!-- CNAME pointing to the .cloudapp.net-->
       <!-- Replace $CertificateThumbprint$ with the thumbprint value find on the ‘Certificate’ tab of your Cloud Service. -->
       <Setting name="DefaultCertificate" value="$CertificateThumbprint$" />
       <Setting name="Skype.Bots.Speech.Subscription" value="$BingSpeechAPIKey$"/>

--- a/Samples/Csharp/RealtimeMedia/TextToSpeech/ServiceDefinition.csdef
+++ b/Samples/Csharp/RealtimeMedia/TextToSpeech/ServiceDefinition.csdef
@@ -31,7 +31,8 @@
     </Startup>
     <ConfigurationSettings>
       <Setting name="Microsoft.WindowsAzure.Plugins.Diagnostics.ConnectionString" />
-      <Setting name="ServiceDnsName" />
+      <Setting name="ServiceDnsName" /><!--This is the .cloudapp.net name of the service-->
+      <Setting name="ServiceCNAME" /><!-- CNAME pointing to the .cloudapp.net if available-->
       <Setting name="DefaultCertificate" />
       <Setting name="Skype.Bots.Speech.Subscription" />
       <Setting name="APPINSIGHTS_INSTRUMENTATIONKEY" />

--- a/Samples/Csharp/RealtimeMedia/TextToSpeech/WorkerRole/AzureConfiguration.cs
+++ b/Samples/Csharp/RealtimeMedia/TextToSpeech/WorkerRole/AzureConfiguration.cs
@@ -125,14 +125,14 @@ namespace WorkerRole
             // Create structured config objects for service.
             CallControlCallbackUrl = new Uri(string.Format(
                 "https://{0}:{1}/{2}/{3}/",
-                ServiceDnsName,
+                ServiceCNAME,
                 instanceCallControlPublicPort,
                 HttpRouteConstants.CallSignalingRoutePrefix,
                 HttpRouteConstants.OnCallbackRoute));
 
             NotificationCallbackUrl = new Uri(string.Format(
                 "https://{0}:{1}/{2}/{3}/",
-                ServiceDnsName,
+                ServiceCNAME,
                 instanceCallControlPublicPort,
                 HttpRouteConstants.CallSignalingRoutePrefix,
                 HttpRouteConstants.OnNotificationRoute));
@@ -165,7 +165,7 @@ namespace WorkerRole
                     InstanceInternalPort = mediaInstanceInternalPort,
                     InstancePublicIPAddress = publicInstanceIpAddress,
                     InstancePublicPort = mediaInstancePublicPort,
-                    ServiceFqdn = ServiceDnsName
+                    ServiceFqdn = ServiceCNAME
                 },
 
                 ApplicationId = MicrosoftAppId

--- a/Samples/Csharp/RealtimeMedia/TextToSpeech/WorkerRole/AzureConfiguration.cs
+++ b/Samples/Csharp/RealtimeMedia/TextToSpeech/WorkerRole/AzureConfiguration.cs
@@ -37,6 +37,7 @@ namespace WorkerRole
         private const string InstanceCallControlEndpointKey = "InstanceCallControlEndpoint";
         private const string InstanceMediaControlEndpointKey = "InstanceMediaControlEndpoint";
         private const string ServiceDnsNameKey = "ServiceDnsName";
+        private const string ServiceCNAMEKey = "ServiceCNAME";
         private const string DefaultCertificateKey = "DefaultCertificate";
         private const string SpeechSubscriptionKey = "Skype.Bots.Speech.Subscription";
         private const string MicrosoftAppIdKey = "MicrosoftAppId";
@@ -61,6 +62,8 @@ namespace WorkerRole
 
         #region Properties
         public string ServiceDnsName { get; private set; }
+
+        public string ServiceCNAME { get; private set; }
 
         public IEnumerable<Uri> CallControlListeningUrls { get; private set; }
 
@@ -90,6 +93,12 @@ namespace WorkerRole
             // Collect config values from Azure config.
             TraceEndpointInfo();
             ServiceDnsName = GetString(ServiceDnsNameKey);
+            ServiceCNAME = GetString(ServiceCNAMEKey, true);
+            if (string.IsNullOrEmpty(ServiceCNAME))
+            {
+                ServiceCNAME = ServiceDnsName;
+            }
+
             X509Certificate2 defaultCertificate = GetCertificateFromStore(DefaultCertificateKey);
 
             RoleInstanceEndpoint instanceCallControlEndpoint = RoleEnvironment.IsEmulated ? null : GetEndpoint(InstanceCallControlEndpointKey);


### PR DESCRIPTION
Hi, I found that using the old property "ServiceDNSName" in old configuration will lead the code to generate wrong CallControlCallbackUrl, wrong NotificationCallbackUrl, and also wrong ServiceFQDN. 

This causes an issue that the Skype bot drops the call right after picks it up, which probably due to the FQDN does not match the CNAME of the certificate.

F.Y.I. I referenced the [HueBot](https://github.com/Microsoft/BotBuilder-RealTimeMediaCalling/tree/master/Samples/HueBot) to make this change.